### PR TITLE
Update README: macport is now up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use Homebrew:
     brew install --cask macfuse
     brew install cryfs/tap/cryfs
 
-If you use MacPorts (only available for OSX 10.12 to 10.14 at the moment):
+If you use MacPorts:
 
     port install cryfs
 


### PR DESCRIPTION
Macport have been updated to 0.11.2 and builds up to the latests OSX version : https://ports.macports.org/port/cryfs/details/